### PR TITLE
보드 헤더 컴포넌트 추가 및 정렬 가능한 보드 아이템에서 통합

### DIFF
--- a/src/components/Board/BoardHeader.tsx
+++ b/src/components/Board/BoardHeader.tsx
@@ -1,0 +1,109 @@
+import {
+    BoardStatus,
+    BOARD_STATUSES,
+    DEFAULT_BOARD_STATUS
+} from "@/constants/board";
+
+interface BoardHeaderProps {
+    title: string;
+    taskCount: number;
+    isEditing: boolean;
+    editTitle: string;
+    onEditTitleChange: (value: string) => void;
+    onEditSubmit: (e: React.FormEvent) => void;
+    onEditCancel: () => void;
+    onEditClick: () => void;
+    onDeleteClick: (e: React.MouseEvent) => void;
+}
+
+export default function BoardHeader({
+    title,
+    taskCount,
+    isEditing,
+    editTitle,
+    onEditTitleChange,
+    onEditSubmit,
+    onEditCancel,
+    onEditClick,
+    onDeleteClick
+}: BoardHeaderProps) {
+    const status = BOARD_STATUSES[title] || DEFAULT_BOARD_STATUS;
+
+    if (isEditing) {
+        return (
+            <form
+                onSubmit={onEditSubmit}
+                className="flex items-center gap-2 w-full"
+            >
+                <input
+                    type="text"
+                    value={editTitle}
+                    onChange={(e) => onEditTitleChange(e.target.value)}
+                    className="flex-1 px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    autoFocus
+                    maxLength={50}
+                />
+                <button
+                    type="submit"
+                    className="px-3 py-1 text-sm text-white bg-blue-500 rounded-lg hover:bg-blue-600"
+                >
+                    저장
+                </button>
+                <button
+                    type="button"
+                    onClick={onEditCancel}
+                    className="px-3 py-1 text-sm text-gray-600 bg-gray-100 rounded-lg hover:bg-gray-200"
+                >
+                    취소
+                </button>
+            </form>
+        );
+    }
+
+    return (
+        <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+                <h3 className="text-lg font-semibold text-black">{title}</h3>
+                <span
+                    className={`px-2 py-1 text-xs rounded-full ${status.color}`}
+                >
+                    {status.text}
+                </span>
+                <span className="text-xs text-gray-500">
+                    ({taskCount}개의 항목)
+                </span>
+            </div>
+            <div className="flex gap-2">
+                <button
+                    onClick={onEditClick}
+                    className="text-gray-500 hover:text-blue-500"
+                >
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="16"
+                        height="16"
+                        fill="currentColor"
+                        viewBox="0 0 16 16"
+                    >
+                        <path d="m13.498.795.149-.149a1.207 1.207 0 1 1 1.707 1.708l-.149.148a1.5 1.5 0 0 1-.059 2.059L4.854 14.854a.5.5 0 0 1-.233.131l-4 1a.5.5 0 0 1-.606-.606l1-4a.5.5 0 0 1 .131-.232l9.642-9.642a.5.5 0 0 0-.642.056L6.854 4.854a.5.5 0 1 1-.708-.708L9.44.854A1.5 1.5 0 0 1 11.5.796a1.5 1.5 0 0 1 1.998-.001z" />
+                    </svg>
+                </button>
+                <button
+                    onClick={onDeleteClick}
+                    className="text-gray-500 hover:text-red-500"
+                >
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="16"
+                        height="16"
+                        fill="currentColor"
+                        viewBox="0 0 16 16"
+                    >
+                        <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z" />
+                        <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/Board/SortableBoardItem.tsx
+++ b/src/components/Board/SortableBoardItem.tsx
@@ -18,32 +18,6 @@ export default function SortableBoardItem({
     const [editTitle, setEditTitle] = useState(title);
     const draggedItemRef = useRef<HTMLDivElement | null>(null);
 
-    const getStatusColor = (title: string) => {
-        switch (title) {
-            case "To do":
-                return "bg-gray-100 text-gray-800";
-            case "In Progress":
-                return "bg-blue-100 text-blue-800";
-            case "Done":
-                return "bg-green-100 text-green-800";
-            default:
-                return "bg-gray-100 text-gray-800";
-        }
-    };
-
-    const getStatusText = (title: string): string => {
-        switch (title) {
-            case "To do":
-                return "할 일";
-            case "In Progress":
-                return "진행 중";
-            case "Done":
-                return "완료";
-            default:
-                return "할 일";
-        }
-    };
-
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         if (!editTitle.trim()) return;

--- a/src/components/Board/SortableBoardItem.tsx
+++ b/src/components/Board/SortableBoardItem.tsx
@@ -2,6 +2,7 @@ import { Board, BoardAction } from "@/types";
 import { useState, useRef } from "react";
 import TaskList from "@/components/Task/TaskList";
 import AddTaskForm from "@/components/Task/AddTaskForm";
+import BoardHeader from "./BoardHeader";
 
 interface SortableBoardItemProps {
     board: Board;
@@ -64,88 +65,17 @@ export default function SortableBoardItem({
 
     return (
         <div ref={draggedItemRef} className="p-4 bg-white rounded-lg shadow-md">
-            <div className="flex items-center justify-between mb-4">
-                {isEditing ? (
-                    <form
-                        onSubmit={handleSubmit}
-                        className="flex items-center gap-2 w-full"
-                    >
-                        <input
-                            type="text"
-                            value={editTitle}
-                            onChange={(e) => setEditTitle(e.target.value)}
-                            className="flex-1 px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                            autoFocus
-                            maxLength={50}
-                        />
-                        <button
-                            type="submit"
-                            className="px-3 py-1 text-sm text-white bg-blue-500 rounded-lg hover:bg-blue-600"
-                        >
-                            저장
-                        </button>
-                        <button
-                            type="button"
-                            onClick={handleCancel}
-                            className="px-3 py-1 text-sm text-gray-600 bg-gray-100 rounded-lg hover:bg-gray-200"
-                        >
-                            취소
-                        </button>
-                    </form>
-                ) : (
-                    <>
-                        <div className="flex items-center gap-2">
-                            <h3 className="text-lg font-semibold text-black">
-                                {board.title}
-                            </h3>
-                            <span
-                                className={`px-2 py-1 text-xs rounded-full ${getStatusColor(
-                                    board.title
-                                )}`}
-                            >
-                                {getStatusText(board.title)}
-                            </span>
-                            <span className="text-xs text-gray-500">
-                                ({tasks.length}개의 항목)
-                            </span>
-                        </div>
-                        <div className="flex gap-2">
-                            <button
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    setIsEditing(true);
-                                }}
-                                className="text-gray-500 hover:text-blue-500"
-                            >
-                                <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    width="16"
-                                    height="16"
-                                    fill="currentColor"
-                                    viewBox="0 0 16 16"
-                                >
-                                    <path d="m13.498.795.149-.149a1.207 1.207 0 1 1 1.707 1.708l-.149.148a1.5 1.5 0 0 1-.059 2.059L4.854 14.854a.5.5 0 0 1-.233.131l-4 1a.5.5 0 0 1-.606-.606l1-4a.5.5 0 0 1 .131-.232l9.642-9.642a.5.5 0 0 0-.642.056L6.854 4.854a.5.5 0 1 1-.708-.708L9.44.854A1.5 1.5 0 0 1 11.5.796a1.5 1.5 0 0 1 1.998-.001z" />
-                                </svg>
-                            </button>
-                            <button
-                                onClick={handleDelete}
-                                className="text-gray-500 hover:text-red-500"
-                            >
-                                <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    width="16"
-                                    height="16"
-                                    fill="currentColor"
-                                    viewBox="0 0 16 16"
-                                >
-                                    <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z" />
-                                    <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4zM2.5 3h11V2h-11z" />
-                                </svg>
-                            </button>
-                        </div>
-                    </>
-                )}
-            </div>
+            <BoardHeader
+                title={title}
+                taskCount={tasks.length}
+                isEditing={isEditing}
+                editTitle={editTitle}
+                onEditTitleChange={setEditTitle}
+                onEditSubmit={handleSubmit}
+                onEditCancel={handleCancel}
+                onEditClick={() => setIsEditing(true)}
+                onDeleteClick={handleDelete}
+            />
 
             <AddTaskForm
                 onSubmit={(title) => boardActions.addTask(id, title)}

--- a/src/constants/board.ts
+++ b/src/constants/board.ts
@@ -1,0 +1,29 @@
+export interface BoardStatus {
+    title: string;
+    color: string;
+    text: string;
+}
+
+export const BOARD_STATUSES: Record<string, BoardStatus> = {
+    "To do": {
+        title: "To do",
+        color: "bg-gray-100 text-gray-800",
+        text: "할 일"
+    },
+    "In Progress": {
+        title: "In Progress",
+        color: "bg-blue-100 text-blue-800",
+        text: "진행 중"
+    },
+    Done: {
+        title: "Done",
+        color: "bg-green-100 text-green-800",
+        text: "완료"
+    }
+};
+
+export const DEFAULT_BOARD_STATUS: BoardStatus = {
+    title: "To do",
+    color: "bg-gray-100 text-gray-800",
+    text: "할 일"
+};


### PR DESCRIPTION
- BoardHeader 컴포넌트를 새로 생성하여 보드 제목, 작업 수, 편집 기능 등을 관리
- SortableBoardItem에서 기존의 헤더 관련 코드를 BoardHeader로 통합하여 코드 중복 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `BoardHeader` component that displays the board title, task count, and a color-coded status indicator.
  - Enabled inline editing for board titles with clear save and cancel controls.

- **Refactor**
  - Simplified the `SortableBoardItem` component by integrating the new `BoardHeader`, leading to a more modular design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->